### PR TITLE
Improve mobile nav and spacing

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -8,12 +8,14 @@ export default function Navigation() {
   const [isScrolled, setIsScrolled] = useState(false);
   const [, navigate] = useLocation();
 
+  const iconColor = isOpen || isScrolled ? "text-dark-gray" : "text-white";
+
   useEffect(() => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 50);
     };
 
-    window.addEventListener("scroll", handleScroll);
+    window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
@@ -83,7 +85,7 @@ export default function Navigation() {
               variant="ghost"
               size="icon"
               onClick={() => setIsOpen(!isOpen)}
-              className="text-dark-gray hover:text-soft-blue"
+              className={`${iconColor} hover:text-soft-blue`}
             >
               {isOpen ? <X className="h-8 w-8" /> : <Menu className="h-8 w-8" />}
             </Button>
@@ -93,31 +95,49 @@ export default function Navigation() {
 
       {/* Mobile Menu */}
       {isOpen && (
-        <div className="md:hidden fixed inset-0 z-[60] bg-white">
+        <div
+          className="md:hidden fixed inset-0 z-[60] bg-white"
+          onClick={() => setIsOpen(false)}
+        >
           {/* Close button in top right */}
           <div className="absolute top-4 right-4">
             <Button
               variant="ghost"
               size="icon"
               onClick={() => setIsOpen(false)}
-              className="text-dark-gray hover:text-soft-blue"
+              className={`${iconColor} hover:text-soft-blue`}
             >
               <X className="h-6 w-6" />
             </Button>
           </div>
           
-          <div className="flex flex-col items-center justify-center h-full space-y-8">
-            {navItems.map((item) => (
-              <button
-                key={item.id}
-                onClick={() => handleNavigation(item)}
-                className="text-2xl font-montserrat font-semibold text-dark-gray hover:text-soft-blue transition-colors duration-300"
-              >
-                {item.label}
-              </button>
-            ))}
-          </div>
+        <div
+          className="flex flex-col items-center justify-center h-full space-y-8"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {navItems.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => handleNavigation(item)}
+              className="text-2xl font-montserrat font-semibold text-dark-gray hover:text-soft-blue transition-colors duration-300"
+            >
+              {item.label}
+            </button>
+          ))}
         </div>
+
+        {/* Close button at bottom for easier access */}
+        <div className="absolute bottom-4 right-4">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setIsOpen(false)}
+            className={`${iconColor} hover:text-soft-blue`}
+          >
+            <X className="h-6 w-6" />
+          </Button>
+        </div>
+      </div>
       )}
     </nav>
   );

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -132,7 +132,7 @@ export default function ServicesSection() {
     <section id="services" className="py-20 bg-white relative overflow-hidden">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Section Header */}
-        <div className="text-center mb-16">
+        <div className="text-center mb-12 md:mb-16">
           <h2 className="section-title font-montserrat font-bold text-3xl md:text-4xl text-dark-gray mb-4">
             Our Services
           </h2>
@@ -140,7 +140,7 @@ export default function ServicesSection() {
         </div>
 
         {/* Services Grid */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16">
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-8 md:mb-16">
           {services.map((service, index) => {
             const IconComponent = service.icon;
             return (


### PR DESCRIPTION
## Summary
- smooth scrolling for nav icon updates
- change hamburger icon color depending on scroll
- add second close button to the mobile menu
- tighten services section spacing on mobile

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_683fbb0b62e883248b30807082d0f8d8