### PR TITLE
Add scroll to top button and hide mobile scrollbars

### DIFF
--- a/client/src/components/scroll-to-top-button.tsx
+++ b/client/src/components/scroll-to-top-button.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export default function ScrollToTopButton() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  return (
+    <div className={`fixed bottom-20 right-6 z-40 ${isVisible ? "block" : "hidden"}`}> 
+      <Button
+        onClick={scrollToTop}
+        size="icon"
+        variant="ghost"
+        className="rounded-full bg-soft-blue text-dark-gray hover:bg-bright-orange"
+      >
+        <ArrowUp className="h-5 w-5" />
+      </Button>
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -228,6 +228,17 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Hide scrollbars on mobile */
+@media (max-width: 767px) {
+  body {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+  body::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-float,

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -13,6 +13,7 @@ import Footer from "@/components/footer";
 import { useGSAPAnimations } from "@/hooks/use-gsap-animations";
 import { MessageCircle, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import ScrollToTopButton from "@/components/scroll-to-top-button";
 
 export default function Home() {
   const [isChatOpen, setIsChatOpen] = useState(false);
@@ -54,7 +55,7 @@ export default function Home() {
         <ContactSection />
       </main>
       <Footer />
-      
+
       {/* Floating Chat Widget */}
       <div className="fixed bottom-6 right-6 z-50">
         <div className="relative">
@@ -107,6 +108,7 @@ export default function Home() {
           </button>
         </div>
       </div>
+      <ScrollToTopButton />
     </div>
   );
 }

--- a/client/src/pages/portfolio.tsx
+++ b/client/src/pages/portfolio.tsx
@@ -5,6 +5,7 @@ import { useGSAPAnimations } from "@/hooks/use-gsap-animations";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ExternalLink, Utensils, Shirt, Coffee, Sparkles, Camera, Users, TrendingUp, Calendar, Target, Award } from "lucide-react";
 import { useLocation } from "wouter";
+import ScrollToTopButton from "@/components/scroll-to-top-button";
 
 export default function Portfolio() {
   const [, navigate] = useLocation();
@@ -285,6 +286,7 @@ export default function Portfolio() {
       </main>
       
       <Footer />
+      <ScrollToTopButton />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add ScrollToTopButton component
- show the new button on Home and Portfolio pages
- hide scrollbars on small screens

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_683fbd27ea5483249311f50d2f7a3394