### PR TITLE
Remove portfolio route and prevent horizontal scroll

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,14 +4,12 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Home from "@/pages/home";
-import Portfolio from "@/pages/portfolio";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Home} />
-      <Route path="/portfolio" component={Portfolio} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/portfolio-section.tsx
+++ b/client/src/components/portfolio-section.tsx
@@ -1,9 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { ExternalLink, Utensils, Shirt, Coffee, Sparkles } from "lucide-react";
-import { useLocation } from "wouter";
 
 export default function PortfolioSection() {
-  const [, navigate] = useLocation();
   
   const scrollToContact = () => {
     const element = document.getElementById("contact");
@@ -92,11 +90,11 @@ export default function PortfolioSection() {
         {/* CTA Button */}
         <div className="text-center">
           <Button
-            onClick={() => navigate('/portfolio')}
+            onClick={scrollToContact}
             className="bg-soft-blue text-white font-montserrat font-semibold px-8 py-4 rounded-2xl hover:bg-blue-400 transform hover:scale-105 transition-all duration-300 shadow-lg"
             size="lg"
           >
-            See Full Portfolio
+            Start Your Project
             <ExternalLink className="ml-3 h-5 w-5" />
           </Button>
         </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -57,6 +57,7 @@
   body {
     @apply bg-background text-foreground font-inter antialiased;
     font-family: 'Inter', sans-serif;
+    overflow-x: hidden;
   }
   
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Summary
- clean up router so the site only has the home route
- update PortfolioSection CTA to scroll to contact instead of navigating
- hide horizontal overflow on body to remove horizontal scrolling

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node', 'vite/client' and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6849754f5570832494d46bd67b8ab52d